### PR TITLE
audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The MigrationLocker contract is responsible for allowing users to lock their PUS
 
 **Key Features:**
 - Token locking mechanism with unique identifier generation
-- Safety toggles to prevent/allow locking - Owner Controlled
+- Openzeppelin's Pausable library to prevent/allow locking - Owner Controlled
 - Proper access control with Ownable2Step pattern
 - Token burning capability for migrated tokens
 - Emergency fund recovery functionality

--- a/src/MigrationLocker.sol
+++ b/src/MigrationLocker.sol
@@ -38,7 +38,7 @@ contract MigrationLocker is Initializable, Ownable2StepUpgradeable, PausableUpgr
     event Locked(address caller, address recipient, uint256 amount, uint256 epoch);
 
     /// @notice Emitted when a admin initiates a new epoch
-    event NewEpoch(uint256 indexed epoch, uint256 indexed startBlock);
+    event NewEpoch(uint256 epoch, uint256 startBlock);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {

--- a/src/MigrationLocker.sol
+++ b/src/MigrationLocker.sol
@@ -33,6 +33,9 @@ contract MigrationLocker is Initializable, Ownable2StepUpgradeable, PausableUpgr
     /// @param epoch The epoch number
     event Locked(address caller, address recipient, uint256 amount, uint256 epoch);
 
+    /// @notice Emitted when a admin initiates a new epoch
+    event NewEpoch(uint256 indexed epoch, uint256 indexed startBlock);
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -49,9 +52,13 @@ contract MigrationLocker is Initializable, Ownable2StepUpgradeable, PausableUpgr
         initiateNewEpoch();
     }
 
+    /// @notice Allows the owner to initiate a new epoch
+    /// @dev The function increments the epoch number and sets the start block for the new epoch
+    /// @dev Emits a NewEpoch event with the epoch number and start block
     function initiateNewEpoch() public onlyOwner {
         epoch++;
         epochStartBlock[epoch] = block.number;
+        emit NewEpoch(epoch, block.number);
     }
 
     /// Pauseable Features
@@ -68,7 +75,7 @@ contract MigrationLocker is Initializable, Ownable2StepUpgradeable, PausableUpgr
     /// @param _recipient The address of the recipient
     /// @dev The recipient address cannot be zero
     /// @dev The function transfers the specified amount of tokens from the user to the contract
-    /// @dev Emits a Locked event with the recipient address, amount, and a unique identifier
+    /// @dev Emits a Locked event with the recipient address, amount, and epoch
     function lock(uint256 _amount, address _recipient) external whenNotPaused {
         uint256 codeLength;
         assembly {

--- a/src/MigrationLocker.sol
+++ b/src/MigrationLocker.sol
@@ -89,6 +89,43 @@ contract MigrationLocker is Initializable, Ownable2StepUpgradeable, PausableUpgr
         emit Locked(msg.sender, _recipient, _amount, epoch);
     }
 
+    /// @notice Allows users to lock their tokens for migration using permit signature
+    /// @param _amount The amount of tokens to lock
+    /// @param _recipient The address of the recipient
+    /// @param _deadline The deadline for the permit signature
+    /// @param _v The v component of the permit signature
+    /// @param _r The r component of the permit signature
+    /// @param _s The s component of the permit signature
+    /// @dev The recipient address cannot be zero
+    /// @dev The function uses permit to approve tokens and then transfers them to the contract
+    /// @dev Emits a Locked event with the recipient address, amount, and epoch
+    function lockWithPermit(
+        uint256 _amount,
+        address _recipient,
+        uint256 _deadline,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    )
+        external
+        whenNotPaused
+    {
+        uint256 codeLength;
+        assembly {
+            codeLength := extcodesize(_recipient)
+        }
+        if (_recipient == address(0) || codeLength > 0) {
+            revert("Invalid recipient");
+        }
+
+        // Use permit to approve tokens for this contract
+        IPUSH(PUSH_TOKEN).permit(msg.sender, address(this), _amount, _deadline, _v, _r, _s);
+
+        // Transfer the approved tokens to this contract
+        IPUSH(PUSH_TOKEN).transferFrom(msg.sender, address(this), _amount);
+        emit Locked(msg.sender, _recipient, _amount, epoch);
+    }
+
     /// @notice Allows the owner to burn a specified amount of tokens
     /// @dev The function can only be called by the contract owner
     /// @param _amount The amount of tokens to burn

--- a/test/MigrationRelease.t.sol
+++ b/test/MigrationRelease.t.sol
@@ -149,7 +149,6 @@ contract MigrationReleaseTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     function testInitialization() public {
-        assertEq(release.isClaimPaused(), false);
         assertEq(release.owner(), owner);
         assertEq(release.merkleRoot(), merkleRoot);
         assertEq(address(release).balance, 10_000 ether);


### PR DESCRIPTION
### This PR contains chages for the following issues:

1. Remove redundant boolean check
2. Removed unused variable 
3. Fix redundant leaf creation
4. Remove unnecessary `return` keyword
5. Fix typo in comments 
6. Added safeERC20 instead of IPUSH for transfers 
7. Added an event for epoch initiation. 
8. Fix natspec for release event. 
9. Fix natspec for lock function. 
10. Update readme with the latest changes 
11. Validate the total amount off-chain and on-chain 
12. Add permit functionality for locking 


### Remaining issues with no changes in this PR 

1. L-06 - We have decided to keep it, as we are only putting the check on the recipient, allowing the smart accounts to lock their tokens but not allowing them to make a contract recipient. 
2. L-07 - In discussion. 
3. L-10 - This has no specific fix in the code. We will use pause/unpause effectively to avoid these scenarios.
4. L-12 - As stated earlier, there will be one Merkle root per epoch, which will only be calculated after pausing the locker and release contracts. 
5. L-15 - Those scripts are not used anywhere important. They are just for debugging. 