### PR TITLE
Track locker-side PUSH reversals and block untracked recovery

### DIFF
--- a/script/deploy/DeployLocker.s.sol
+++ b/script/deploy/DeployLocker.s.sol
@@ -20,6 +20,7 @@ contract DeployLockerScript is Script {
         // Get private key from environment
         uint256 deployerPrivateKey = vm.envUint("DEPLOYER_OWNER");
         address deployerAddress = vm.addr(deployerPrivateKey);
+        bool refundsEnabled = vm.envOr("REFUNDS_ENABLED", false);
 
         vm.startBroadcast(deployerPrivateKey);
 
@@ -30,7 +31,8 @@ contract DeployLockerScript is Script {
 
         bytes memory initData = abi.encodeWithSelector(
             MigrationLocker.initialize.selector,
-            deployerAddress // Set deployer as initial owner
+            deployerAddress, // Set deployer as initial owner
+            refundsEnabled
         );
 
         TransparentUpgradeableProxy proxy =

--- a/script/testSimulations/DeployAndRunOnSepolia.js
+++ b/script/testSimulations/DeployAndRunOnSepolia.js
@@ -4,6 +4,7 @@ const { ethers } = require("hardhat");
 
 async function main() {
   const TOKEN_ADDRESS = "0x37c779a1564DCc0e3914aB130e0e787d93e21804"; // PUSH Token
+  const refundsEnabled = process.env.REFUNDS_ENABLED === "true";
   const amountToMint = ethers.parseUnits("1000", 18); // amount each user gets
   const amountToLock = ethers.parseUnits("100", 18);  // amount each user locks
   const amountToLock2 = ethers.parseUnits("250", 18);  // amount each user locks
@@ -22,7 +23,7 @@ async function main() {
   // const locker = MigrationLocker.attach("0x5f4A632526a907003879dAd557dBdcf624EBe992");
   const locker = await upgrades.deployProxy(
     MigrationLocker,
-    [deployer.address],
+    [deployer.address, refundsEnabled],
     { kind: "transparent", initializer: "initialize" }
   );
   await locker.waitForDeployment();

--- a/script/utils/config.js
+++ b/script/utils/config.js
@@ -6,7 +6,7 @@ const LOCKER_CONFIG = {
   CONTRACT_ADDRESS: "",
   ABI: [
     "event Locked(address caller, address recipient, uint256 amount, uint256 epoch)",
-    "event Unlocked(address sender, address recipient, uint256 amount, uint256 epoch)",
+    "event Unlocked(address indexed sender, address indexed recipient, uint256 amount, uint256 epoch)",
     "function epoch() view returns (uint256)",
     "function epochStartBlock(uint256) view returns (uint256)"
   ],

--- a/script/utils/config.js
+++ b/script/utils/config.js
@@ -1,20 +1,18 @@
 /**
- * Configuration for event fetching and merkle proof generation
+ * Configuration for event fetching and merkle proof generation.
  */
 
-// MigrationLocker contract configuration
 const LOCKER_CONFIG = {
   CONTRACT_ADDRESS: "",
   ABI: [
     "event Locked(address caller, address recipient, uint256 amount, uint256 epoch)",
+    "event Unlocked(address sender, address recipient, uint256 amount, uint256 epoch)",
     "function epoch() view returns (uint256)",
     "function epochStartBlock(uint256) view returns (uint256)"
   ],
-  // Optional: Filter specific epochs (leave empty to process all epochs)
-  FILTER_EPOCHS: [] // e.g. [1, 2] to only process epochs 1 and 2
+  FILTER_EPOCHS: []
 };
 
-// Output configuration
 const OUTPUT_CONFIG = {
   CLAIMS_PATH: "../../output/migration-list.json"
 };
@@ -22,4 +20,4 @@ const OUTPUT_CONFIG = {
 module.exports = {
   LOCKER_CONFIG,
   OUTPUT_CONFIG
-}; 
+};

--- a/script/utils/fetchAndStoreEvents.js
+++ b/script/utils/fetchAndStoreEvents.js
@@ -1,169 +1,273 @@
 const fs = require("fs");
 const path = require("path");
-const { ethers } = require("hardhat");
 const { LOCKER_CONFIG, OUTPUT_CONFIG } = require("./config");
 
-async function main() {
-  const CONTRACT_ADDRESS = LOCKER_CONFIG.CONTRACT_ADDRESS;
-  const LOCKER_ABI = LOCKER_CONFIG.ABI;
-  const FILTER_EPOCHS = LOCKER_CONFIG.FILTER_EPOCHS;
-  const PUSH_TOKEN_ADDRESS = "0xf418588522d5dd018b425E472991E52EBBeEEEEE";
+const PUSH_TOKEN_ADDRESS = "0xf418588522d5dd018b425E472991E52EBBeEEEEE";
+const PUSH_TOKEN_ABI = [
+  "function balanceOf(address account) view returns (uint256)"
+];
 
-  const provider = ethers.provider;
-  const locker = new ethers.Contract(CONTRACT_ADDRESS, LOCKER_ABI, provider);
+function toBigInt(value) {
+  return typeof value === "bigint" ? value : BigInt(value.toString());
+}
 
-  // Add PUSH token interface for balance validation
-  const pushToken = new ethers.Contract(PUSH_TOKEN_ADDRESS, [
-    "function balanceOf(address account) view returns (uint256)"
-  ], provider);
+function senderRecipientEpochKey(sender, recipient, epoch) {
+  return `${sender.toLowerCase()}-${recipient.toLowerCase()}-${epoch}`;
+}
 
-  // Get current epoch from contract
-  const currentEpoch = await locker.epoch();
-  console.log(`🔢 Current epoch: ${currentEpoch}`);
+function recipientEpochKey(recipient, epoch) {
+  return `${recipient.toLowerCase()}-${epoch}`;
+}
 
-  // Determine which epochs to process
-  let epochsToProcess = [];
-  if (FILTER_EPOCHS && FILTER_EPOCHS.length > 0) {
-    epochsToProcess = FILTER_EPOCHS.filter(e => e <= currentEpoch);
-    console.log(`🔍 Processing specific epochs: ${epochsToProcess.join(', ')}`);
-  } else {
-    // Process all epochs from 1 to current
-    for (let i = 1; i <= currentEpoch; i++) {
-      epochsToProcess.push(i);
+function addAmountByEpoch(totalsByEpoch, epoch, amount) {
+  const key = epoch.toString();
+  totalsByEpoch[key] = (totalsByEpoch[key] || 0n) + amount;
+}
+
+function buildNetClaims(lockedEntries, unlockedEntries = []) {
+  const senderRecipientBalances = Object.create(null);
+  const recipientEpochBalances = Object.create(null);
+  const lockedTotalsByEpoch = Object.create(null);
+  const unlockedTotalsByEpoch = Object.create(null);
+
+  for (const entry of lockedEntries) {
+    const amount = toBigInt(entry.amount);
+    const epoch = entry.epoch.toString();
+    const key = senderRecipientEpochKey(entry.sender, entry.recipient, epoch);
+    const current = senderRecipientBalances[key];
+
+    if (current) {
+      current.amount += amount;
+    } else {
+      senderRecipientBalances[key] = {
+        sender: entry.sender,
+        recipient: entry.recipient,
+        epoch,
+        amount
+      };
     }
-    console.log(`🔍 Processing all epochs from 1 to ${currentEpoch}`);
+
+    addAmountByEpoch(lockedTotalsByEpoch, epoch, amount);
   }
 
-  // Get the overall start and end blocks for the entire range
+  for (const entry of unlockedEntries) {
+    const amount = toBigInt(entry.amount);
+    const epoch = entry.epoch.toString();
+    const key = senderRecipientEpochKey(entry.sender, entry.recipient, epoch);
+    const current = senderRecipientBalances[key];
+
+    if (!current || current.amount < amount) {
+      throw new Error(
+        `Negative net amount for ${entry.sender} -> ${entry.recipient} in epoch ${epoch}`
+      );
+    }
+
+    current.amount -= amount;
+    addAmountByEpoch(unlockedTotalsByEpoch, epoch, amount);
+  }
+
+  for (const claimableBalance of Object.values(senderRecipientBalances)) {
+    if (claimableBalance.amount === 0n) {
+      continue;
+    }
+
+    const key = recipientEpochKey(claimableBalance.recipient, claimableBalance.epoch);
+    const current = recipientEpochBalances[key];
+
+    if (current) {
+      current.amount += claimableBalance.amount;
+    } else {
+      recipientEpochBalances[key] = {
+        address: claimableBalance.recipient,
+        amount: claimableBalance.amount,
+        epoch: claimableBalance.epoch
+      };
+    }
+  }
+
+  const claims = Object.values(recipientEpochBalances)
+    .filter((claim) => claim.amount > 0n)
+    .sort((a, b) => {
+      if (a.epoch !== b.epoch) {
+        return Number(a.epoch) - Number(b.epoch);
+      }
+      return a.address.toLowerCase().localeCompare(b.address.toLowerCase());
+    })
+    .map((claim) => ({
+      address: claim.address,
+      amount: claim.amount.toString(),
+      epoch: claim.epoch
+    }));
+
+  return {
+    claims,
+    lockedTotalsByEpoch,
+    unlockedTotalsByEpoch
+  };
+}
+
+function normalizeLockedEvents(events) {
+  return events.map((event) => ({
+    sender: event.args.caller,
+    recipient: event.args.recipient,
+    amount: event.args.amount,
+    epoch: Number(event.args.epoch)
+  }));
+}
+
+function normalizeUnlockedEvents(events) {
+  return events.map((event) => ({
+    sender: event.args.sender,
+    recipient: event.args.recipient,
+    amount: event.args.amount,
+    epoch: Number(event.args.epoch)
+  }));
+}
+
+async function getEpochsToProcess(locker, filterEpochs) {
+  const currentEpoch = Number(await locker.epoch());
+  let epochsToProcess = [];
+
+  if (filterEpochs && filterEpochs.length > 0) {
+    epochsToProcess = filterEpochs.filter((epoch) => epoch <= currentEpoch);
+  } else {
+    for (let epoch = 1; epoch <= currentEpoch; epoch++) {
+      epochsToProcess.push(epoch);
+    }
+  }
+
+  return {
+    currentEpoch,
+    epochsToProcess
+  };
+}
+
+async function getEpochWindow(locker, currentEpoch, epochsToProcess) {
+  if (epochsToProcess.length === 0) {
+    return null;
+  }
+
   const firstEpoch = Math.min(...epochsToProcess);
   const lastEpoch = Math.max(...epochsToProcess);
+  const startBlock = Number(await locker.epochStartBlock(firstEpoch));
 
-  const startBlock = await locker.epochStartBlock(firstEpoch);
   let endBlock = "latest";
   if (lastEpoch < currentEpoch) {
     const nextEpochStart = await locker.epochStartBlock(lastEpoch + 1);
     endBlock = Number(nextEpochStart) - 1;
   }
 
-  console.log(`📊 Fetching all Locked events from blocks ${startBlock} to ${endBlock}...`);
+  return { startBlock, endBlock };
+}
 
-  // Single query for all events in the range
-  const allEvents = await locker.queryFilter("Locked", startBlock, endBlock);
-  console.log(`📦 Found ${allEvents.length} total Locked events`);
+async function getOnChainEpochDelta(pushToken, locker, contractAddress, epoch, currentEpoch) {
+  if (epoch === currentEpoch) {
+    const currentBalance = toBigInt(await pushToken.balanceOf(contractAddress));
+    const epochStart = Number(await locker.epochStartBlock(currentEpoch));
+    const balanceBeforeEpoch = toBigInt(
+      await pushToken.balanceOf(contractAddress, { blockTag: epochStart - 1 })
+    );
 
-  // Group events by address and combine amounts
-  const addressAmounts = {};
-  let totalEvents = 0;
-  const epochTotals = {}; // Track total amount per epoch from events
-
-  // Process events and filter by epoch on the client side
-  for (const event of allEvents) {
-    const eventEpoch = Number(event.args.epoch);
-
-    // Skip events from epochs we're not interested in
-    if (!epochsToProcess.includes(eventEpoch)) {
-      continue;
-    }
-
-    const address = event.args.recipient;
-    const amount = BigInt(event.args.amount.toString());
-
-    const key = `${address}-${eventEpoch}`;
-
-    if (addressAmounts[key]) {
-      // Address already exists in this epoch, add to existing amount
-      addressAmounts[key].amount = addressAmounts[key].amount + amount;
-      console.log(`📝 Combined amount for ${address} in epoch ${eventEpoch}`);
-    } else {
-      // First occurrence of this address in this epoch
-      addressAmounts[key] = {
-        address: address,
-        amount: amount,
-        epoch: eventEpoch.toString()
-      };
-    }
-
-    // Track total per epoch
-    if (!epochTotals[eventEpoch]) {
-      epochTotals[eventEpoch] = BigInt(0);
-    }
-    epochTotals[eventEpoch] += amount;
-
-    totalEvents++;
+    return currentBalance - balanceBeforeEpoch;
   }
 
-  // Convert to array format with combined amounts
-  const claims = Object.values(addressAmounts).map(claim => ({
-    address: claim.address,
-    amount: claim.amount.toString(),
-    epoch: claim.epoch
-  }));
+  const epochStart = Number(await locker.epochStartBlock(epoch));
+  const nextEpochStart = Number(await locker.epochStartBlock(epoch + 1));
+  const endBalance = toBigInt(
+    await pushToken.balanceOf(contractAddress, { blockTag: nextEpochStart - 1 })
+  );
+  const startBalance = toBigInt(
+    await pushToken.balanceOf(contractAddress, { blockTag: epochStart - 1 })
+  );
 
-  console.log(`📊 Processed ${totalEvents} events into ${claims.length} unique address-epoch combinations`);
+  return endBalance - startBalance;
+}
 
-  // Show some statistics
-  const duplicateCount = totalEvents - claims.length;
-  if (duplicateCount > 0) {
-    console.log(`🔄 Combined ${duplicateCount} duplicate addresses`);
-  }
-
-  // Validate that sum of all leaves equals on-chain locked amounts
-  console.log(`\n🔍 Validating totals against on-chain state...`);
+async function validateSourceEpochTotals(source, sourceResult, pushToken, locker, currentEpoch, epochsToProcess) {
+  console.log(`\n🔍 Validating ${source.NAME} against on-chain balances...`);
 
   for (const epoch of epochsToProcess) {
-    const offChainTotal = epochTotals[epoch] || BigInt(0);
+    const epochKey = epoch.toString();
+    const lockedTotal = sourceResult.lockedTotalsByEpoch[epochKey] || 0n;
+    const unlockedTotal = sourceResult.unlockedTotalsByEpoch[epochKey] || 0n;
+    const offChainNet = lockedTotal - unlockedTotal;
+    const onChainNet = await getOnChainEpochDelta(
+      pushToken,
+      locker,
+      source.CONTRACT_ADDRESS,
+      epoch,
+      currentEpoch
+    );
 
-    // Get on-chain total (incremental balance for this epoch)
-    let onChainTotal;
-    if (epoch === currentEpoch) {
-      // For current epoch: current balance minus balance at start of current epoch
-      const currentBalance = await pushToken.balanceOf(CONTRACT_ADDRESS);
-      const currentEpochStart = await locker.epochStartBlock(currentEpoch);
-      const balanceAtStart = await pushToken.balanceOf(CONTRACT_ADDRESS, {
-        blockTag: Number(currentEpochStart) - 1
-      });
-      onChainTotal = currentBalance - balanceAtStart;
-    } else {
-      // For past epochs: balance at end of epoch minus balance at start of epoch
-      const nextEpochStart = await locker.epochStartBlock(epoch + 1);
-      const epochStart = await locker.epochStartBlock(epoch);
-
-      const endBlockOfEpoch = Number(nextEpochStart) - 1;
-      const startBlockOfEpoch = Number(epochStart) - 1;
-
-      const endBalance = await pushToken.balanceOf(CONTRACT_ADDRESS, { blockTag: endBlockOfEpoch });
-      const startBalance = await pushToken.balanceOf(CONTRACT_ADDRESS, { blockTag: startBlockOfEpoch });
-      onChainTotal = endBalance - startBalance;
+    if (offChainNet !== onChainNet) {
+      console.error(`❌ Validation failed for ${source.NAME} epoch ${epoch}:`);
+      console.error(`   Locked total: ${lockedTotal.toString()}`);
+      console.error(`   Unlocked total: ${unlockedTotal.toString()}`);
+      console.error(`   Off-chain net: ${offChainNet.toString()}`);
+      console.error(`   On-chain net: ${onChainNet.toString()}`);
+      throw new Error(`Funds mismatch for ${source.NAME} epoch ${epoch}`);
     }
 
-    if (offChainTotal !== onChainTotal) {
-      console.error(`❌ Validation failed for epoch ${epoch}:`);
-      console.error(`   Off-chain total: ${offChainTotal.toString()}`);
-      console.error(`   On-chain total: ${onChainTotal.toString()}`);
-      console.error(`   Difference: ${(offChainTotal > onChainTotal ? offChainTotal - onChainTotal : onChainTotal - offChainTotal).toString()}`);
-      throw new Error(`Funds may be missing for epoch ${epoch}`);
-    }
+    console.log(
+      `✅ ${source.NAME} epoch ${epoch}: ${lockedTotal.toString()} locked, ${unlockedTotal.toString()} unlocked, ${offChainNet.toString()} net`
+    );
+  }
+}
 
-    console.log(`✅ Epoch ${epoch}: ${offChainTotal.toString()} wei`);
+async function main() {
+  const { ethers } = require("hardhat");
+
+  const provider = ethers.provider;
+  const pushToken = new ethers.Contract(PUSH_TOKEN_ADDRESS, PUSH_TOKEN_ABI, provider);
+  const locker = new ethers.Contract(LOCKER_CONFIG.CONTRACT_ADDRESS, LOCKER_CONFIG.ABI, provider);
+  const source = { NAME: "migration-locker", CONTRACT_ADDRESS: LOCKER_CONFIG.CONTRACT_ADDRESS };
+
+  const { currentEpoch, epochsToProcess } = await getEpochsToProcess(locker, LOCKER_CONFIG.FILTER_EPOCHS);
+
+  if (epochsToProcess.length === 0) {
+    console.log(`⚠️  No epochs to process (current epoch: ${currentEpoch})`);
+    return;
   }
 
-  console.log(`\n✅ All validations passed!`);
+  const epochWindow = await getEpochWindow(locker, currentEpoch, epochsToProcess);
+  console.log(`\n📦 Processing locker: ${LOCKER_CONFIG.CONTRACT_ADDRESS}`);
+  console.log(`   Current epoch: ${currentEpoch}`);
+  console.log(`   Epochs: ${epochsToProcess.join(", ")}`);
+  console.log(`   Blocks: ${epochWindow.startBlock} -> ${epochWindow.endBlock}`);
+
+  const lockedEvents = await locker.queryFilter("Locked", epochWindow.startBlock, epochWindow.endBlock);
+  const unlockedEvents = await locker.queryFilter("Unlocked", epochWindow.startBlock, epochWindow.endBlock);
+
+  const filteredLockedEvents = normalizeLockedEvents(lockedEvents).filter((event) =>
+    epochsToProcess.includes(event.epoch)
+  );
+  const filteredUnlockedEvents = normalizeUnlockedEvents(unlockedEvents).filter((event) =>
+    epochsToProcess.includes(event.epoch)
+  );
+
+  const sourceResult = buildNetClaims(filteredLockedEvents, filteredUnlockedEvents);
+
+  console.log(`   Locked events: ${filteredLockedEvents.length}`);
+  console.log(`   Unlocked events: ${filteredUnlockedEvents.length}`);
+  console.log(`   Net claims: ${sourceResult.claims.length}`);
+
+  await validateSourceEpochTotals(source, sourceResult, pushToken, locker, currentEpoch, epochsToProcess);
 
   const outputPath = path.join(__dirname, OUTPUT_CONFIG.CLAIMS_PATH);
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-  fs.writeFileSync(outputPath, JSON.stringify(claims, null, 2));
+  fs.writeFileSync(outputPath, JSON.stringify(sourceResult.claims, null, 2));
 
-  console.log(`✅ Saved ${claims.length} unique claims to ${outputPath}`);
-
-  // Optional: Show top 5 addresses by amount for verification
-  const sortedClaims = claims.sort((a, b) => {
-    const amountA = BigInt(a.amount);
-    const amountB = BigInt(b.amount);
-    return amountB > amountA ? 1 : amountB < amountA ? -1 : 0;
-  });
+  console.log(`\n✅ Saved ${sourceResult.claims.length} net claims to ${outputPath}`);
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+module.exports = {
+  buildNetClaims,
+  main
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/script/utils/fetchAndStoreEvents.test.js
+++ b/script/utils/fetchAndStoreEvents.test.js
@@ -1,0 +1,58 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { buildNetClaims } = require("./fetchAndStoreEvents");
+
+const alice = "0x00000000000000000000000000000000000000a1";
+const bob = "0x00000000000000000000000000000000000000b2";
+const carol = "0x00000000000000000000000000000000000000c3";
+
+test("buildNetClaims handles locked entries", () => {
+  const result = buildNetClaims([
+    { sender: alice, recipient: bob, amount: 100n, epoch: 1 }
+  ]);
+
+  assert.deepEqual(result.claims, [
+    { address: bob, amount: "100", epoch: "1" }
+  ]);
+  assert.equal(result.lockedTotalsByEpoch["1"], 100n);
+  assert.equal(result.unlockedTotalsByEpoch["1"] || 0n, 0n);
+});
+
+test("buildNetClaims subtracts unlocked entries from the correct sender-recipient-epoch bucket", () => {
+  const result = buildNetClaims(
+    [
+      { sender: alice, recipient: bob, amount: 100n, epoch: 1 },
+      { sender: carol, recipient: bob, amount: 50n, epoch: 1 }
+    ],
+    [
+      { sender: alice, recipient: bob, amount: 30n, epoch: 1 }
+    ]
+  );
+
+  assert.deepEqual(result.claims, [
+    { address: bob, amount: "120", epoch: "1" }
+  ]);
+  assert.equal(result.lockedTotalsByEpoch["1"], 150n);
+  assert.equal(result.unlockedTotalsByEpoch["1"], 30n);
+});
+
+test("buildNetClaims drops fully refunded entries", () => {
+  const result = buildNetClaims(
+    [{ sender: alice, recipient: bob, amount: 100n, epoch: 1 }],
+    [{ sender: alice, recipient: bob, amount: 100n, epoch: 1 }]
+  );
+
+  assert.deepEqual(result.claims, []);
+});
+
+test("buildNetClaims rejects negative net amounts", () => {
+  assert.throws(
+    () =>
+      buildNetClaims(
+        [{ sender: alice, recipient: bob, amount: 10n, epoch: 1 }],
+        [{ sender: alice, recipient: bob, amount: 11n, epoch: 1 }]
+      ),
+    /Negative net amount/
+  );
+});

--- a/script/utils/fetchAndStoreEvents.test.js
+++ b/script/utils/fetchAndStoreEvents.test.js
@@ -1,11 +1,28 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { ethers } = require("hardhat");
 
+const { LOCKER_CONFIG } = require("./config");
 const { buildNetClaims } = require("./fetchAndStoreEvents");
 
 const alice = "0x00000000000000000000000000000000000000a1";
 const bob = "0x00000000000000000000000000000000000000b2";
 const carol = "0x00000000000000000000000000000000000000c3";
+
+test("LOCKER_CONFIG ABI decodes indexed Unlocked logs", () => {
+  const eventAbi = [
+    "event Unlocked(address indexed sender, address indexed recipient, uint256 amount, uint256 epoch)"
+  ];
+  const actualInterface = new ethers.Interface(eventAbi);
+  const builderInterface = new ethers.Interface(LOCKER_CONFIG.ABI);
+  const encoded = actualInterface.encodeEventLog(actualInterface.getEvent("Unlocked"), [alice, bob, 100n, 1n]);
+  const decoded = builderInterface.decodeEventLog("Unlocked", encoded.data, encoded.topics);
+
+  assert.equal(decoded.sender.toLowerCase(), alice);
+  assert.equal(decoded.recipient.toLowerCase(), bob);
+  assert.equal(decoded.amount, 100n);
+  assert.equal(decoded.epoch, 1n);
+});
 
 test("buildNetClaims handles locked entries", () => {
   const result = buildNetClaims([

--- a/src/MigrationLocker.sol
+++ b/src/MigrationLocker.sol
@@ -25,6 +25,10 @@ contract MigrationLocker is Initializable, Ownable2StepUpgradeable, PausableUpgr
     mapping(uint256 => uint256) public epochStartBlock;
     /// @notice The address of the PUSH token
     address public constant PUSH_TOKEN = 0xf418588522d5dd018b425E472991E52EBBeEEEEE;
+    /// @notice Indicates whether owner-driven refunds are enabled for this locker instance
+    bool public refundsEnabled;
+    /// @notice Tracks the still-claimable refundable amount by sender, recipient, and epoch
+    mapping(address => mapping(address => mapping(uint256 => uint256))) public lockedBySenderRecipientEpoch;
 
     /**
      * EVENTS and ERRORS ******
@@ -39,6 +43,8 @@ contract MigrationLocker is Initializable, Ownable2StepUpgradeable, PausableUpgr
 
     /// @notice Emitted when a admin initiates a new epoch
     event NewEpoch(uint256 epoch, uint256 startBlock);
+    /// @notice Emitted when the owner refunds locked tokens back to the original sender
+    event Unlocked(address indexed sender, address indexed recipient, uint256 amount, uint256 epoch);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -47,11 +53,13 @@ contract MigrationLocker is Initializable, Ownable2StepUpgradeable, PausableUpgr
 
     /// @notice Initializes the contract instead of constructor
     /// @param initialOwner The address of the admin
-    function initialize(address initialOwner) public initializer {
+    /// @param refundsEnabled_ Whether this locker instance supports owner-driven refunds
+    function initialize(address initialOwner, bool refundsEnabled_) public initializer {
         require(initialOwner != address(0), "Invalid owner");
         __Ownable2Step_init();
         __Ownable_init(initialOwner);
         __Pausable_init();
+        refundsEnabled = refundsEnabled_;
 
         initiateNewEpoch();
     }
@@ -90,6 +98,7 @@ contract MigrationLocker is Initializable, Ownable2StepUpgradeable, PausableUpgr
         }
 
         IERC20(PUSH_TOKEN).safeTransferFrom(msg.sender, address(this), _amount);
+        lockedBySenderRecipientEpoch[msg.sender][_recipient][epoch] += _amount;
         emit Locked(msg.sender, _recipient, _amount, epoch);
     }
 
@@ -125,9 +134,32 @@ contract MigrationLocker is Initializable, Ownable2StepUpgradeable, PausableUpgr
         // Use permit to approve tokens for this contract
         IPUSH(PUSH_TOKEN).permit(msg.sender, address(this), _amount, _deadline, _v, _r, _s);
 
-        // Transfer the approved tokens to this contract
         IERC20(PUSH_TOKEN).safeTransferFrom(msg.sender, address(this), _amount);
+        lockedBySenderRecipientEpoch[msg.sender][_recipient][epoch] += _amount;
         emit Locked(msg.sender, _recipient, _amount, epoch);
+    }
+
+    /// @notice Allows the owner to refund locked PUSH back to the original sender
+    /// @param _sender The original locker address that supplied the PUSH
+    /// @param _recipient The claim recipient that was set during locking
+    /// @param _amount The amount to refund
+    /// @param _epoch The epoch bucket from which to refund
+    function refundLockedFunds(address _sender, address _recipient, uint256 _amount, uint256 _epoch)
+        external
+        onlyOwner
+        whenNotPaused
+    {
+        require(refundsEnabled, "Refunds disabled");
+        require(_sender != address(0), "Invalid sender");
+        require(_amount > 0, "Invalid amount");
+
+        uint256 refundableAmount = lockedBySenderRecipientEpoch[_sender][_recipient][_epoch];
+        require(refundableAmount >= _amount, "Insufficient locked balance");
+
+        lockedBySenderRecipientEpoch[_sender][_recipient][_epoch] = refundableAmount - _amount;
+        IERC20(PUSH_TOKEN).safeTransfer(_sender, _amount);
+
+        emit Unlocked(_sender, _recipient, _amount, _epoch);
     }
 
     /// @notice Allows the owner to burn a specified amount of tokens
@@ -139,6 +171,7 @@ contract MigrationLocker is Initializable, Ownable2StepUpgradeable, PausableUpgr
     }
 
     function recoverFunds(address _token, address _to, uint256 _amount) external onlyOwner whenNotPaused {
+        require(_token != PUSH_TOKEN, "PUSH recovery disabled");
         require(_to != address(0), "Invalid recipient");
 
         require(_amount > 0 && _amount <= IERC20(_token).balanceOf(address(this)), "Invalid amount");

--- a/test/MigrationLocker.t.sol
+++ b/test/MigrationLocker.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.29;
 import "forge-std/Test.sol";
 import "./mocks/PushTokenMock.sol";
 import "../src/MigrationLocker.sol";
+import "../src/interfaces/IPush.sol";
 import { IPushMock } from "./interfaces/v8/IPushMock.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
@@ -19,86 +20,82 @@ contract MigrationLockerTest is Test {
     address public user1;
     address public user2;
     address public user3;
+    address public otherToken;
 
     uint256 public constant INITIAL_BALANCE = 1000 ether;
     uint256 public constant LOCK_AMOUNT_1 = 100 ether;
     uint256 public constant LOCK_AMOUNT_2 = 200 ether;
     uint256 public constant LOCK_AMOUNT_3 = 300 ether;
 
-    // Import the event from MigrationLocker
     event Locked(address caller, address recipient, uint256 amount, uint256 epoch);
+    event Unlocked(address indexed sender, address indexed recipient, uint256 amount, uint256 epoch);
 
     function setUp() public {
         owner = address(this);
         user1 = makeAddr("user1");
         user2 = makeAddr("user2");
         user3 = makeAddr("user3");
+        otherToken = makeAddr("otherToken");
 
-        // Deploy the mock PUSH token
         pushToken = new PushTokenMock();
-
-        // Mint tokens to users
         pushToken.mint(user1, INITIAL_BALANCE);
         pushToken.mint(user2, INITIAL_BALANCE);
         pushToken.mint(user3, INITIAL_BALANCE);
 
-        // Deploy the MigrationLocker contract implementation
         implementation = new MigrationLocker();
-
-        // Deploy ProxyAdmin
         proxyAdmin = new ProxyAdmin(owner);
+        locker = _deployLocker(true);
 
-        // Initialize data for the proxy
-        bytes memory initData = abi.encodeWithSelector(MigrationLocker.initialize.selector, owner);
-
-        // Deploy the TransparentUpgradeableProxy
-        proxy = new TransparentUpgradeableProxy(address(implementation), address(proxyAdmin), initData);
-
-        // Create a contract instance pointing to the proxy
-        locker = MigrationLocker(address(proxy));
-
-        // Deploy dummy version for the PUSH_TOKEN
         vm.mockCall(
             address(locker.PUSH_TOKEN()), abi.encodeWithSelector(IPushMock.transferFrom.selector), abi.encode(true)
         );
-
+        vm.mockCall(address(locker.PUSH_TOKEN()), abi.encodeWithSelector(IPUSH.permit.selector), abi.encode());
         vm.mockCall(address(locker.PUSH_TOKEN()), abi.encodeWithSelector(IPushMock.burn.selector), abi.encode());
-
         vm.mockCall(
             address(locker.PUSH_TOKEN()), abi.encodeWithSelector(IPushMock.balanceOf.selector), abi.encode(1000 ether)
         );
-
         vm.mockCall(address(locker.PUSH_TOKEN()), abi.encodeWithSelector(IPushMock.transfer.selector), abi.encode(true));
+    }
+
+    function _deployLocker(bool refundsEnabled) internal returns (MigrationLocker deployedLocker) {
+        bytes memory initData = abi.encodeWithSelector(MigrationLocker.initialize.selector, owner, refundsEnabled);
+        proxy = new TransparentUpgradeableProxy(address(implementation), address(proxyAdmin), initData);
+        deployedLocker = MigrationLocker(address(proxy));
+    }
+
+    function _lockFrom(address sender, address recipient, uint256 amount) internal {
+        vm.prank(sender);
+        locker.lock(amount, recipient);
     }
 
     /*//////////////////////////////////////////////////////////////
                              INITIALIZATION TESTS
     //////////////////////////////////////////////////////////////*/
 
-    function testInitialization() public {
+    function testInitialization() public view {
         assertEq(locker.paused(), false);
         assertEq(locker.owner(), owner);
+        assertEq(locker.epoch(), 1);
+        assertEq(locker.refundsEnabled(), true);
+    }
+
+    function testInitializationCanDisableRefunds() public {
+        MigrationLocker refundsDisabledLocker = _deployLocker(false);
+        assertEq(refundsDisabledLocker.refundsEnabled(), false);
+        assertEq(refundsDisabledLocker.epoch(), 1);
     }
 
     function testInitiateNewEpoch() public {
-        // Get the current epoch
         uint256 initialEpoch = locker.epoch();
 
-        // Advance the block
         vm.roll(block.number + 10);
-
-        // Call initiateNewEpoch
         locker.initiateNewEpoch();
 
-        // Verify epoch was incremented
         assertEq(locker.epoch(), initialEpoch + 1);
-
-        // Verify the new epoch's start block was set correctly
         assertEq(locker.epochStartBlock(initialEpoch + 1), block.number);
     }
 
     function testOnlyOwnerCanInitiateNewEpoch() public {
-        // Try to call initiateNewEpoch as non-owner
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(OwnableUnauthorizedAccount.selector, user1));
         locker.initiateNewEpoch();
@@ -107,8 +104,7 @@ contract MigrationLockerTest is Test {
     function testCannotInitializeWithZeroAddress() public {
         MigrationLocker newImplementation = new MigrationLocker();
         ProxyAdmin newProxyAdmin = new ProxyAdmin(owner);
-
-        bytes memory initData = abi.encodeWithSelector(MigrationLocker.initialize.selector, address(0));
+        bytes memory initData = abi.encodeWithSelector(MigrationLocker.initialize.selector, address(0), true);
 
         vm.expectRevert("Invalid owner");
         new TransparentUpgradeableProxy(address(newImplementation), address(newProxyAdmin), initData);
@@ -116,7 +112,7 @@ contract MigrationLockerTest is Test {
 
     function testCannotReinitialize() public {
         vm.expectRevert(abi.encodeWithSelector(InvalidInitialization.selector));
-        locker.initialize(address(this));
+        locker.initialize(address(this), true);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -140,40 +136,43 @@ contract MigrationLockerTest is Test {
     }
 
     /*//////////////////////////////////////////////////////////////
-                             LOCK TESTS
+                                 LOCK TESTS
     //////////////////////////////////////////////////////////////*/
 
     function testLock() public {
-        // Set up the expected event
         vm.expectEmit(true, true, true, true);
-        // The caller is the test contract itself, not user1
-        emit Locked(address(this), user1, LOCK_AMOUNT_1, locker.epoch());
+        emit Locked(user1, user2, LOCK_AMOUNT_1, locker.epoch());
+        vm.prank(user1);
+        locker.lock(LOCK_AMOUNT_1, user2);
 
-        // Now call the function
-        locker.lock(LOCK_AMOUNT_1, user1);
+        assertEq(locker.lockedBySenderRecipientEpoch(user1, user2, locker.epoch()), LOCK_AMOUNT_1);
     }
 
-    function testLockUpdatesBalance() public {
-        uint256 initialBalance = pushToken.balanceOf(user1);
-        uint256 initialBalanceLocker = pushToken.balanceOf(address(locker));
+    function testLockWithPermitIncrementsTrackedBalance() public {
+        uint256 deadline = block.timestamp + 1 days;
 
-        console.log("initialBalance", initialBalance);
-        console.log("initialBalanceLocker", initialBalanceLocker);
-
-        // We expect a call to transferFrom with these parameters
         vm.expectCall(
             address(locker.PUSH_TOKEN()),
-            abi.encodeWithSelector(IPushMock.transferFrom.selector, user1, address(locker), LOCK_AMOUNT_1)
+            abi.encodeWithSelector(
+                IPUSH.permit.selector,
+                user1,
+                address(locker),
+                LOCK_AMOUNT_2,
+                deadline,
+                27,
+                bytes32(uint256(1)),
+                bytes32(uint256(2))
+            )
+        );
+        vm.expectCall(
+            address(locker.PUSH_TOKEN()),
+            abi.encodeWithSelector(IPushMock.transferFrom.selector, user1, address(locker), LOCK_AMOUNT_2)
         );
 
         vm.prank(user1);
-        locker.lock(LOCK_AMOUNT_1, user1);
+        locker.lockWithPermit(LOCK_AMOUNT_2, user2, deadline, 27, bytes32(uint256(1)), bytes32(uint256(2)));
 
-        console.log("Test passed: transferFrom was called with correct parameters");
-
-        // The reason balances don't change is because we've mocked the transferFrom function
-        // in the setUp function, but the actual transfer isn't happening since it's just a mock.
-        // In a real scenario, the balances would change as expected.
+        assertEq(locker.lockedBySenderRecipientEpoch(user1, user2, locker.epoch()), LOCK_AMOUNT_2);
     }
 
     function testCannotLockWhenPaused() public {
@@ -197,15 +196,97 @@ contract MigrationLockerTest is Test {
     }
 
     /*//////////////////////////////////////////////////////////////
-                             BURN TESTS
+                                REFUND TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function testRefundLockedFundsReturnsToOriginalSender() public {
+        _lockFrom(user1, user2, LOCK_AMOUNT_1);
+
+        vm.expectEmit(true, true, true, true);
+        emit Unlocked(user1, user2, 40 ether, locker.epoch());
+        vm.expectCall(address(locker.PUSH_TOKEN()), abi.encodeWithSelector(IPushMock.transfer.selector, user1, 40 ether));
+
+        locker.refundLockedFunds(user1, user2, 40 ether, locker.epoch());
+
+        assertEq(locker.lockedBySenderRecipientEpoch(user1, user2, locker.epoch()), 60 ether);
+    }
+
+    function testRefundReducesOnlyRequestedSenderRecipientEpochBucket() public {
+        _lockFrom(user1, user2, LOCK_AMOUNT_1);
+        _lockFrom(user1, user3, LOCK_AMOUNT_2);
+        _lockFrom(user2, user2, LOCK_AMOUNT_3);
+
+        locker.initiateNewEpoch();
+        _lockFrom(user1, user2, 25 ether);
+
+        locker.refundLockedFunds(user1, user2, 30 ether, 1);
+
+        assertEq(locker.lockedBySenderRecipientEpoch(user1, user2, 1), 70 ether);
+        assertEq(locker.lockedBySenderRecipientEpoch(user1, user3, 1), LOCK_AMOUNT_2);
+        assertEq(locker.lockedBySenderRecipientEpoch(user2, user2, 1), LOCK_AMOUNT_3);
+        assertEq(locker.lockedBySenderRecipientEpoch(user1, user2, 2), 25 ether);
+    }
+
+    function testPartialRefundPreservesRemainingBalance() public {
+        _lockFrom(user1, user2, LOCK_AMOUNT_1);
+
+        locker.refundLockedFunds(user1, user2, 10 ether, locker.epoch());
+        locker.refundLockedFunds(user1, user2, 15 ether, locker.epoch());
+
+        assertEq(locker.lockedBySenderRecipientEpoch(user1, user2, locker.epoch()), 75 ether);
+    }
+
+    function testCannotRefundMoreThanTrackedBalance() public {
+        _lockFrom(user1, user2, LOCK_AMOUNT_1);
+        uint256 currentEpoch = locker.epoch();
+
+        vm.expectRevert("Insufficient locked balance");
+        locker.refundLockedFunds(user1, user2, LOCK_AMOUNT_1 + 1, currentEpoch);
+    }
+
+    function testCannotRefundWhenRefundsDisabled() public {
+        MigrationLocker refundsDisabledLocker = _deployLocker(false);
+        uint256 currentEpoch = refundsDisabledLocker.epoch();
+
+        vm.mockCall(
+            address(refundsDisabledLocker.PUSH_TOKEN()),
+            abi.encodeWithSelector(IPushMock.transferFrom.selector),
+            abi.encode(true)
+        );
+
+        vm.prank(user1);
+        refundsDisabledLocker.lock(LOCK_AMOUNT_1, user2);
+
+        vm.expectRevert("Refunds disabled");
+        refundsDisabledLocker.refundLockedFunds(user1, user2, 1 ether, currentEpoch);
+    }
+
+    function testOnlyOwnerCanRefundLockedFunds() public {
+        _lockFrom(user1, user2, LOCK_AMOUNT_1);
+        uint256 currentEpoch = locker.epoch();
+
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUnauthorizedAccount.selector, user1));
+        locker.refundLockedFunds(user1, user2, 1 ether, currentEpoch);
+    }
+
+    function testCannotRefundWhenPaused() public {
+        _lockFrom(user1, user2, LOCK_AMOUNT_1);
+        locker.pause();
+        uint256 currentEpoch = locker.epoch();
+
+        vm.expectRevert(abi.encodeWithSelector(EnforcedPause.selector));
+        locker.refundLockedFunds(user1, user2, 1 ether, currentEpoch);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                 BURN TESTS
     //////////////////////////////////////////////////////////////*/
 
     function testBurn() public {
         uint256 burnAmount = 100 ether;
 
-        // Mock the burn call
         vm.expectCall(address(locker.PUSH_TOKEN()), abi.encodeWithSelector(IPushMock.burn.selector, burnAmount));
-
         locker.burn(burnAmount);
     }
 
@@ -218,7 +299,6 @@ contract MigrationLockerTest is Test {
     function testCannotBurnWhenPaused() public {
         locker.pause();
 
-        // Include EnforcedPause()
         vm.expectRevert(abi.encodeWithSelector(EnforcedPause.selector));
         locker.burn(100 ether);
     }
@@ -227,164 +307,92 @@ contract MigrationLockerTest is Test {
                           RECOVER FUNDS TESTS
     //////////////////////////////////////////////////////////////*/
 
-    function testRecoverFunds() public {
+    function testCannotRecoverPushFunds() public {
+        address pushTokenAddress = locker.PUSH_TOKEN();
+
+        vm.expectRevert("PUSH recovery disabled");
+        locker.recoverFunds(pushTokenAddress, user1, 100 ether);
+    }
+
+    function testRecoverNonPushFunds() public {
         uint256 recoverAmount = 100 ether;
 
-        // Mock the transfer call
-        vm.expectCall(
-            address(locker.PUSH_TOKEN()), abi.encodeWithSelector(IPushMock.transfer.selector, user1, recoverAmount)
-        );
+        vm.mockCall(otherToken, abi.encodeWithSelector(IPushMock.balanceOf.selector, address(locker)), abi.encode(1000 ether));
+        vm.mockCall(otherToken, abi.encodeWithSelector(IPushMock.transfer.selector), abi.encode(true));
 
-        locker.recoverFunds(address(locker.PUSH_TOKEN()), user1, recoverAmount);
+        vm.expectCall(otherToken, abi.encodeWithSelector(IPushMock.transfer.selector, user1, recoverAmount));
+        locker.recoverFunds(otherToken, user1, recoverAmount);
     }
 
     function testOnlyOwnerCanRecoverFunds() public {
-        // Setup the mock call for balanceOf
-        vm.mockCall(
-            address(locker.PUSH_TOKEN()),
-            abi.encodeWithSelector(IPushMock.balanceOf.selector, address(proxy)),
-            abi.encode(1000 ether)
-        );
-
-        address token = address(locker.PUSH_TOKEN());
-        address recipient = user2;
-        uint256 amount = 100 ether;
+        vm.mockCall(otherToken, abi.encodeWithSelector(IPushMock.balanceOf.selector, address(locker)), abi.encode(1000 ether));
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(OwnableUnauthorizedAccount.selector, user1));
-        locker.recoverFunds(token, recipient, amount);
+        locker.recoverFunds(otherToken, user2, 100 ether);
     }
 
     function testCannotRecoverWhenPaused() public {
-        // First toggle the lock
         locker.pause();
+        vm.mockCall(otherToken, abi.encodeWithSelector(IPushMock.balanceOf.selector, address(locker)), abi.encode(1000 ether));
 
-        // Setup the mock call for balanceOf
-        vm.mockCall(
-            address(locker.PUSH_TOKEN()),
-            abi.encodeWithSelector(IPushMock.balanceOf.selector, address(proxy)),
-            abi.encode(1000 ether)
-        );
-
-        address token = address(locker.PUSH_TOKEN());
-        address recipient = user1;
-        uint256 amount = 100 ether;
-
-        // Include EnforcedPause()
         vm.expectRevert(abi.encodeWithSelector(EnforcedPause.selector));
-        locker.recoverFunds(token, recipient, amount);
+        locker.recoverFunds(otherToken, user1, 100 ether);
     }
 
     function testCannotRecoverToZeroAddress() public {
-        // Setup the mock call for balanceOf
-        vm.mockCall(
-            address(locker.PUSH_TOKEN()),
-            abi.encodeWithSelector(IPushMock.balanceOf.selector, address(proxy)),
-            abi.encode(1000 ether)
-        );
-
-        address token = address(locker.PUSH_TOKEN());
-        address zeroAddress = address(0);
-        uint256 amount = 100 ether;
+        vm.mockCall(otherToken, abi.encodeWithSelector(IPushMock.balanceOf.selector, address(locker)), abi.encode(1000 ether));
 
         vm.expectRevert("Invalid recipient");
-        locker.recoverFunds(token, zeroAddress, amount);
+        locker.recoverFunds(otherToken, address(0), 100 ether);
     }
 
     function testCannotRecoverZeroAmount() public {
-        // Setup the mock call for balanceOf
-        vm.mockCall(
-            address(locker.PUSH_TOKEN()),
-            abi.encodeWithSelector(IPushMock.balanceOf.selector, address(proxy)),
-            abi.encode(1000 ether)
-        );
-
-        address token = address(locker.PUSH_TOKEN());
-        address recipient = user1;
-        uint256 zeroAmount = 0;
+        vm.mockCall(otherToken, abi.encodeWithSelector(IPushMock.balanceOf.selector, address(locker)), abi.encode(1000 ether));
 
         vm.expectRevert("Invalid amount");
-        locker.recoverFunds(token, recipient, zeroAmount);
+        locker.recoverFunds(otherToken, user1, 0);
     }
 
     function testCannotRecoverMoreThanBalance() public {
-        // Define a token address
-        address token = address(locker.PUSH_TOKEN());
+        vm.mockCall(otherToken, abi.encodeWithSelector(IPushMock.balanceOf.selector, address(locker)), abi.encode(500 ether));
 
-        // Set up the mock for balanceOf
-        // Note: We need to use address(proxy) which is the same as address(locker)
-        vm.mockCall(
-            token,
-            abi.encodeWithSelector(IPushMock.balanceOf.selector, address(proxy)),
-            abi.encode(500 ether) // Contract balance is 500 ether
-        );
-
-        // Try to recover 1000 ether (more than contract balance)
-        uint256 amountToRecover = 1000 ether;
-
-        // Verify that it reverts with "Invalid amount"
         vm.expectRevert("Invalid amount");
-        locker.recoverFunds(token, user1, amountToRecover);
+        locker.recoverFunds(otherToken, user1, 1000 ether);
     }
 
+    /*//////////////////////////////////////////////////////////////
+                         ACTUAL TOKEN TRANSFER TESTS
+    //////////////////////////////////////////////////////////////*/
+
     function testActualTokenTransfer() public {
-        // Deploy a new instance of everything for a clean test environment
         PushTokenMock newToken = new PushTokenMock();
-        MigrationLocker newImplementation = new MigrationLocker();
-        ProxyAdmin newProxyAdmin = new ProxyAdmin(owner);
-
-        // Initialize data for the proxy
-        bytes memory initData = abi.encodeWithSelector(MigrationLocker.initialize.selector, owner);
-
-        // Deploy the proxy
-        TransparentUpgradeableProxy newProxy =
-            new TransparentUpgradeableProxy(address(newImplementation), address(newProxyAdmin), initData);
-
-        // Create contract instance
-        MigrationLocker newLocker = MigrationLocker(address(newProxy));
-
-        // Set up test account and mint tokens
         address testUser = makeAddr("testUser");
         newToken.mint(testUser, 1000 ether);
 
-        // Create a custom locker just for this test with direct access to our token
         MockMigrationLocker customLocker = new MockMigrationLocker(address(newToken));
 
-        // Initial balances
         uint256 initialUserBalance = newToken.balanceOf(testUser);
         uint256 initialLockerBalance = newToken.balanceOf(address(customLocker));
 
-        console.log("Initial user balance:", initialUserBalance);
-        console.log("Initial locker balance:", initialLockerBalance);
-
-        // Approve tokens
         vm.prank(testUser);
         newToken.approve(address(customLocker), 100 ether);
 
-        // Lock tokens
         vm.prank(testUser);
         customLocker.lock(100 ether, testUser);
 
-        // Check final balances
         uint256 finalUserBalance = newToken.balanceOf(testUser);
         uint256 finalLockerBalance = newToken.balanceOf(address(customLocker));
 
-        console.log("Final user balance:", finalUserBalance);
-        console.log("Final locker balance:", finalLockerBalance);
-
-        // Verify balances changed correctly
         assertEq(finalUserBalance, initialUserBalance - 100 ether);
         assertEq(finalLockerBalance, initialLockerBalance + 100 ether);
     }
 }
 
-// @dev this is Custom mock locker that uses a test dummy token instead of the hardcoded one.
-// @dev primarily made for the testActualTokenTransfer() to work without mockCalls
 contract MockMigrationLocker is Initializable, Ownable2StepUpgradeable, PausableUpgradeable {
     event Locked(address caller, address recipient, uint256 amount, uint256 epoch);
 
     uint256 public epoch = 1;
-
     address public immutable PUSH_TOKEN;
 
     constructor(address tokenAddress) {


### PR DESCRIPTION
## Summary

This PR fixes the locker-side accounting gap where PUSH could leave `MigrationLocker` without being reflected in the off-chain claim builder.

## Changes

- track locked balance per `sender + recipient + epoch`
- add `Unlocked(sender, recipient, amount, epoch)`
- add `refundLockedFunds(...)` to return PUSH to the original sender through an explicit tracked path
- block `recoverFunds(PUSH_TOKEN, ...)`
- update the single-locker event builder to generate claims from `Locked - Unlocked`
- update deployment/init flows to pass `refundsEnabled`

## Scope

- no change to `MigrationRelease`
- no change to Merkle leaf format
- no change to release-side claim flow